### PR TITLE
Update dashlane.rb

### DIFF
--- a/Casks/dashlane.rb
+++ b/Casks/dashlane.rb
@@ -1,6 +1,6 @@
 cask 'dashlane' do
-  version '6.1907.0.17860'
-  sha256 '9d335e0447d43b8222ef0e0cdd8d4c0be9c53a142db8a0c9aea1c43198824c5c'
+  version '6.1905.1.17465'
+  sha256 '0f4714b89aa9e6fa90774ad2022a676d3cb12574f5f36c2d39841bcd204a08d1'
 
   url "https://cdn5.dashlane.com/proxy/d3mfqat9ni8wb5/releases/#{version.major_minor_patch}/#{version}/release/Dashlane.dmg"
   appcast 'https://ws1.dashlane.com/5/binaries/query?target=archive&format=xml&currentSoftwareVersion=6.0.0&platform=server_osx&os=OS_X_10_14_1'


### PR DESCRIPTION
As requested in https://github.com/reitermarkus/homebrew-cask/pull/9.

There weren’t any open version bumps, so let’s do the reverse. Confirmed beforehand that this old file still exists upstream.